### PR TITLE
Prevent race condition

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -171,7 +171,7 @@ func getWalker(w *Watcher, root string, addch chan<- *watchItem) func(string, os
 			return nil
 		}
 		wi := watchPath(path)
-		if wi == nil {
+		if wi == nil || wi.StatInfo == nil {
 			return nil
 		} else if _, watching := w.paths[wi.Path]; !watching {
 			wi.LastEvent = CREATED


### PR DESCRIPTION
It seems a somewhat sequence of adding/modifying/deleting temporary files sometimes triggers a race condition, sometimes resulting a panic accessing wi.StatInfo. Adding a nil check resolved the issue.